### PR TITLE
Simple Qt SPARQL client and data objects for NDC

### DIFF
--- a/eddy/core/ndc.py
+++ b/eddy/core/ndc.py
@@ -34,29 +34,31 @@
 
 
 from dataclasses import dataclass
-from textwrap import dedent, indent
-from typing import Union, Optional, Iterable
+from textwrap import dedent
+from typing import (
+    Iterable,
+    Optional,
+    Union,
+)
 
-from SPARQLWrapper import SPARQLWrapper, RDF as rdf
-from rdflib import Graph, RDF, URIRef, Literal, Dataset
+from rdflib import (
+    Dataset,
+    Graph,
+    Literal,
+    URIRef,
+)
 from rdflib.namespace import (
     FOAF,
     DCAT,
     DCTERMS,
+    RDF,
     DefinedNamespace,
     Namespace,
 )
 from rdflib.store import Store
 
-from eddy.core.commands.iri import CommandIRIAddAnnotationAssertion
 from eddy.core.functions.fsystem import fexists
 from eddy.core.functions.path import expandPath
-from eddy.core.owl import AnnotationAssertion, OWL2Datatype
-
-# Create the default store if not exists yet
-if not fexists(expandPath('@data/rdf-store.ttl')):
-    with open(expandPath('@data/rdf-store.ttl'), 'w') as store:
-        store.writelines(['# NDC default triple store'])
 
 
 # Subset of the l0 ontology vocabulary
@@ -459,279 +461,3 @@ UNION {Project.bgp()}
         Saves this dataset to the default user destination.
         """
         self.serialize(NDCDataset.STORE_PATH, format='trig')
-
-
-def sendQuery(query, endpointURL):
-    sparql = SPARQLWrapper(endpointURL)
-    sparql.setQuery(query)
-    sparql.setReturnFormat(rdf)
-    resultGraph = sparql.query().convert()
-    '''for res in qres["results"]["bindings"]:
-        print(res)'''
-    return resultGraph
-
-
-def extractAgents(endpointURL):
-    prefix = """
-            PREFIX dct: <http://purl.org/dc/terms/>
-            PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            """
-    query = """CONSTRUCT {
-                ?x a foaf:Agent.
-                ?x foaf:name ?y0.
-                ?x dct:identifier ?y1.
-                } WHERE {
-              ?x a foaf:Agent.
-              OPTIONAL {
-                ?x foaf:name ?y0.
-              }.
-              OPTIONAL {
-                ?x dct:identifier ?y1.
-              }.
-            }"""
-    graph = sendQuery(prefix+query, endpointURL)
-    return graph
-
-
-def extractContactPoints(endpointURL):
-    prefix = """
-                PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                """
-    query = """CONSTRUCT {
-                  ?x a vcard:Kind.
-                  ?x vcard:fn ?y0.
-                  ?x vcard:hasEmail ?y1.
-                  ?x vcard:hasTelephone ?y2.
-                } WHERE {
-                  ?x a vcard:Kind.
-                  OPTIONAL {
-                    ?x vcard:fn ?y0.
-                  }.
-                  OPTIONAL {
-                    ?x vcard:hasEmail ?y1.
-                  }.
-                  OPTIONAL {
-                    ?x vcard:hasTelephone ?y2.
-                  }.
-                }"""
-    graph = sendQuery(prefix+query, endpointURL)
-    return graph
-
-
-def extractProjects(endpointURL):
-    prefix = """
-                    PREFIX l0: <https://w3id.org/italia/onto/l0/>
-                    PREFIX ADMS: <https://w3id.org/italia/onto/ADMS/>
-                    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                    """
-    query = """CONSTRUCT {
-                    ?x a ADMS:Project.
-                    ?x l0:name ?y0.
-                } WHERE {
-                  ?x a ADMS:Project.
-                  OPTIONAL {
-                    ?x l0:name ?y0.
-                  }.
-                }"""
-    graph = sendQuery(prefix+query, endpointURL)
-    return graph
-
-
-def extractDistributions(endpointURL):
-    prefix = """PREFIX dct: <http://purl.org/dc/terms/>
-                PREFIX dcat: <http://www.w3.org/ns/dcat#>
-                PREFIX ADMS: <https://w3id.org/italia/onto/ADMS/>
-                PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-                """
-    query = """CONSTRUCT {
-                  ?x a ADMS:SemanticAssetDistribution.
-                  ?x dct:title ?y0.
-                  ?x dct:description ?y1.
-                  ?x dct:format ?y2.
-                  ?x dct:license ?y3.
-                  ?x dcat:accessURL ?y4.
-                  ?x dcat:downloadURL ?y5.
-                } WHERE {
-                  ?x a ADMS:SemanticAssetDistribution.
-                  OPTIONAL {
-                    ?x dct:title ?y0.
-                  }.
-                  OPTIONAL {
-                    ?x dct:description ?y1.
-                  }.
-                  OPTIONAL {
-                    ?x dct:format ?y2.
-                  }.
-                  OPTIONAL {
-                    ?x dct:license ?y3.
-                  }.
-                  OPTIONAL {
-                    ?x dcat:accessURL ?y4.
-                  }.
-                  OPTIONAL {
-                    ?x dcat:downloadURL ?y5.
-                  }.
-                }"""
-    graph = sendQuery(prefix+query, endpointURL)
-    return graph
-
-
-def getDataFromEndpoint(endpointURL):
-    # endpoint = "https://schema.gov.it/sparql"
-    if endpointURL:
-        agentsGraph = extractAgents(endpointURL)
-        distributionGraph = extractDistributions(endpointURL)
-        contactPointsGraph = extractContactPoints(endpointURL)
-        projectsGraph = extractProjects(endpointURL)
-        graph = agentsGraph + distributionGraph + contactPointsGraph + projectsGraph
-        graphName = endpointURL.replace('https://', '[').replace('/', ']')
-        graph.serialize(destination=expandPath(f'@data/{graphName}.ttl'))
-    return True
-
-
-def getAgentsFromStore(endpointURL):
-    agents = [""]
-    graphName = endpointURL.replace('https://', '[').replace('/', ']')
-    g1 = Graph()
-    g1.parse(expandPath(f'@data/{graphName}.ttl'))
-    g2 = Graph()
-    g2.parse(expandPath('@data/rdf-store.ttl'))
-    g = g1 + g2
-    for s, p, o in g.triples((None, RDF.type, FOAF.Agent)):
-        agents.append(s)
-    return agents
-
-
-def getContactPointsFromStore(endpointURL):
-    contacts = [""]
-    graphName = endpointURL.replace('https://', '[').replace('/', ']')
-    g1 = Graph()
-    g1.parse(expandPath(f'@data/{graphName}.ttl'))
-    g2 = Graph()
-    g2.parse(expandPath('@data/rdf-store.ttl'))
-    g = g1 + g2
-    for s, p, o in g.triples((None, RDF.type, URIRef("http://www.w3.org/2006/vcard/ns#Kind"))):
-        contacts.append(s)
-    return contacts
-
-
-def getProjectsFromStore(endpointURL):
-    projects = [""]
-    graphName = endpointURL.replace('https://', '[').replace('/', ']')
-    g1 = Graph()
-    g1.parse(expandPath(f'@data/{graphName}.ttl'))
-    g2 = Graph()
-    g2.parse(expandPath('@data/rdf-store.ttl'))
-    g = g1 + g2
-    for s, p, o in g.triples(
-        (None, RDF.type, URIRef("https://w3id.org/italia/onto/ADMS/Project"))):
-        projects.append(s)
-    return projects
-
-
-def getDistributionsFromStore(endpointURL):
-    distributions = [""]
-    graphName = endpointURL.replace('https://', '[').replace('/', ']')
-    g1 = Graph()
-    g1.parse(expandPath(f'@data/{graphName}.ttl'))
-    g2 = Graph()
-    g2.parse(expandPath('@data/rdf-store.ttl'))
-    g = g1 + g2
-    for s, p, o in g.triples(
-        (None, RDF.type, URIRef("https://w3id.org/italia/onto/ADMS/SemanticAssetDistribution"))):
-        distributions.append(s)
-    return distributions
-
-
-def addAgentToStore(iri, nameIT, nameEN, id):
-    dest = expandPath('@data/rdf-store.ttl')
-    g = Graph()
-    g.parse(dest)
-    iriRef = URIRef(iri)
-    nameITlit = Literal(nameIT, lang='it')
-    nameENlit = Literal(nameEN,  lang='en')
-    idLit = Literal(id, datatype=RDF.PlainLiteral)
-    g.add((iriRef, RDF.type, FOAF.Agent))
-    g.add((iriRef, FOAF.name, nameITlit))
-    g.add((iriRef, FOAF.name, nameENlit))
-    g.add((iriRef, URIRef('http://purl.org/dc/terms/identifier'), idLit))
-    g.serialize(dest)
-    return
-
-
-def addProjectToStore(iri, nameIT, nameEN):
-    dest = expandPath('@data/rdf-store.ttl')
-    g = Graph()
-    g.parse(dest)
-    iriRef = URIRef(iri)
-    nameITlit = Literal(nameIT,  lang='it')
-    nameENlit = Literal(nameEN,  lang='en')
-    g.add((iriRef, RDF.type, URIRef("https://w3id.org/italia/onto/ADMS/Project")))
-    g.add((iriRef, URIRef("https://w3id.org/italia/onto/l0/name"), nameITlit))
-    g.add((iriRef, URIRef("https://w3id.org/italia/onto/l0/name"), nameENlit))
-    g.serialize(dest)
-    return
-
-
-def addDistributionToStore(iri, titleIT, titleEN, descriptionIT, descriptionEN, format, license, accessURL, downloadURL):
-    dest = expandPath('@data/rdf-store.ttl')
-    g = Graph()
-    g.parse(dest)
-    iriRef = URIRef(iri)
-    titleITlit = Literal(titleIT, lang='it')
-    titleENlit = Literal(titleEN,  lang='en')
-    descriptionITlit = Literal(descriptionIT, lang='it')
-    descriptionENlit = Literal(descriptionEN, lang='en')
-    formatLit = URIRef(format)
-    licenseLit = URIRef(license)
-    accessURLlit = URIRef(accessURL)
-    downloadURLlit = URIRef(downloadURL)
-    g.add((iriRef, RDF.type, URIRef("https://w3id.org/italia/onto/ADMS/SemanticAssetDistribution")))
-    g.add((iriRef, URIRef('http://purl.org/dc/terms/title'), titleITlit))
-    g.add((iriRef, URIRef('http://purl.org/dc/terms/title'), titleENlit))
-    g.add((iriRef, URIRef('http://purl.org/dc/terms/description'), descriptionITlit))
-    g.add((iriRef, URIRef('http://purl.org/dc/terms/description'), descriptionENlit))
-    g.add((iriRef, URIRef('http://purl.org/dc/terms/format'), formatLit))
-    g.add((iriRef, URIRef('http://purl.org/dc/terms/license'), licenseLit))
-    g.add((iriRef, URIRef('http://www.w3.org/ns/dcat#accessURL'), accessURLlit))
-    g.add((iriRef, URIRef('http://www.w3.org/ns/dcat#downloadURL'), downloadURLlit))
-    g.serialize(dest)
-    return
-
-
-def addContactToStore(iri, nameIT, nameEN, email, telephone):
-    dest = expandPath('@data/rdf-store.ttl')
-    g = Graph()
-    g.parse(dest)
-    iriRef = URIRef(iri)
-    nameITlit = Literal(nameIT,  lang='it')
-    nameENlit = Literal(nameEN,  lang='en')
-    emailLit = URIRef(email)
-    telephoneLit = Literal(telephone)
-    g.add((iriRef, RDF.type, URIRef("http://www.w3.org/2006/vcard/ns#Kind")))
-    g.add((iriRef, URIRef("http://www.w3.org/2006/vcard/ns#fn"), nameITlit))
-    g.add((iriRef, URIRef("http://www.w3.org/2006/vcard/ns#fn"), nameENlit))
-    g.add((iriRef, URIRef("http://www.w3.org/2006/vcard/ns#hasEmail"), emailLit))
-    g.add((iriRef, URIRef("http://www.w3.org/2006/vcard/ns#hasTelephone"), telephoneLit))
-    g.serialize(dest)
-    return
-
-def addIriAnnotationsToProject(url, project, subjectIri):
-    graphName = url.replace('https://', '[').replace('/', ']')
-    g1 = Graph()
-    g1.parse(expandPath(f'@data/{graphName}.ttl'))
-    g2 = Graph()
-    g2.parse(expandPath('@data/rdf-store.ttl'))
-    g = g1 + g2
-    for s, p, o in g.triples((URIRef(subjectIri), None, None)):
-        annotationAssertion = AnnotationAssertion(project.getIRI(subjectIri), project.getIRI(p.toPython()),
-                                                  o.toPython() if isinstance(o, Literal) else project.getIRI(o.toPython()), OWL2Datatype.PlainLiteral.value if isinstance(o, Literal) else None, o.language if isinstance(o, Literal) else None)
-        command = CommandIRIAddAnnotationAssertion(project, project.getIRI(subjectIri), annotationAssertion)
-        project.session.undostack.push(command)
-    return

--- a/eddy/core/ndc.py
+++ b/eddy/core/ndc.py
@@ -36,6 +36,7 @@
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import (
+    ClassVar,
     Iterable,
     Optional,
     Union,
@@ -90,6 +91,7 @@ class VCARD(DefinedNamespace):
 
 @dataclass
 class Agent:
+    type: ClassVar[URIRef] = FOAF.Agent
     uri: URIRef
     name_en: Optional[Literal]
     name_it: Optional[Literal]
@@ -101,21 +103,22 @@ class Agent:
         :return: the list  of triples representing this instance.
         """
         return [
-            (self.uri, RDF.type, FOAF.Agent),
+            (self.uri, RDF.type, Agent.type),
             (self.uri, FOAF.name, self.name_en),
             (self.uri, FOAF.name, self.name_it),
             (self.uri, DCTERMS.identifier, self.identifier),
         ]
 
     @staticmethod
-    def bgp() -> str:
+    def bgp(uri: Optional[URIRef] = None) -> str:
         """
         The SPARQL BGP that identifies instances of this class in an RDF dataset.
+        :param uri: optional uri of the element to filter for
         :return: the SPARQL BGP
         """
         return dedent(f"""
-        {{
-            ?agent a {FOAF.Agent.n3()} .
+        {{ {f'BIND( {uri.n3()} AS ?agent)' if uri else ''}
+            ?agent a {Agent.type.n3()} .
             OPTIONAL {{
                 ?agent {FOAF.name.n3()} ?name_en .
                 FILTER langMatches(lang(?name_en), 'en')
@@ -136,7 +139,7 @@ class Agent:
         :return: the SPARQL CONSTRUCT head
         """
         return dedent(f"""
-        ?agent a {FOAF.Agent.n3()} ;
+        ?agent a {Agent.type.n3()} ;
                {FOAF.name.n3()} ?name_en ;
                {FOAF.name.n3()} ?name_it ;
                {DCTERMS.identifier.n3()} ?id .
@@ -154,11 +157,12 @@ class Agent:
 
 @dataclass
 class ContactPoint:
+    type: ClassVar[URIRef] = VCARD.Kind
     uri: URIRef
     fn_en: Optional[Literal]
     fn_it: Optional[Literal]
-    email: Optional[Literal]
-    telephone: Optional[Literal]
+    email: Optional[URIRef]
+    telephone: Optional[URIRef]
 
     def triples(self) -> Iterable:
         """
@@ -166,21 +170,23 @@ class ContactPoint:
         :return: the list  of triples representing this instance.
         """
         return [
-            (self.uri, RDF.type, VCARD.Kind),
+            (self.uri, RDF.type, ContactPoint.type),
             (self.uri, VCARD.fn, self.fn_en),
             (self.uri, VCARD.fn, self.fn_it),
             (self.uri, VCARD.hasEmail, self.email),
+            (self.uri, VCARD.hasTelephone, self.telephone),
         ]
 
     @staticmethod
-    def bgp() -> str:
+    def bgp(uri: Optional[URIRef] = None) -> str:
         """
         The SPARQL BGP that identifies instances of this class in an RDF dataset.
+        :param uri: optional uri of the element to filter for
         :return: the SPARQL BGP
         """
         return dedent(f"""
-        {{
-            ?contact a {VCARD.Kind.n3()} .
+        {{ {f'BIND( {uri.n3()} AS ?contact)' if uri else ''}
+            ?contact a {ContactPoint.type.n3()} .
             OPTIONAL {{
                 ?contact {VCARD.fn.n3()} ?fn_en .
                 FILTER langMatches(lang(?fn_en), 'en')
@@ -202,7 +208,7 @@ class ContactPoint:
         :return: the SPARQL CONSTRUCT head
         """
         return dedent(f"""
-        ?contact a {VCARD.Kind.n3()} ;
+        ?contact a {ContactPoint.type.n3()} ;
                  {VCARD.fn.n3()} ?fn_en ;
                  {VCARD.fn.n3()} ?fn_it ;
                  {VCARD.hasEmail.n3()} ?email ;
@@ -221,13 +227,14 @@ class ContactPoint:
 
 @dataclass
 class Distribution:
+    type: ClassVar[URIRef] = ADMS.SemanticAssetDistribution
     uri: URIRef
     title_en: Optional[Literal]
     title_it: Optional[Literal]
     description_en: Optional[Literal]
     description_it: Optional[Literal]
-    format: Optional[Literal]
-    license: Optional[Literal]
+    format: Optional[URIRef]
+    license: Optional[URIRef]
     accessURL: Optional[URIRef]
     downloadURL: Optional[URIRef]
 
@@ -237,7 +244,7 @@ class Distribution:
         :return: the list  of triples representing this instance.
         """
         return [
-            (self.uri, RDF.type, ADMS.SemanticAssetDistribution),
+            (self.uri, RDF.type, Distribution.type),
             (self.uri, DCTERMS.title, self.title_en),
             (self.uri, DCTERMS.title, self.title_it),
             (self.uri, DCTERMS.description, self.description_en),
@@ -249,14 +256,15 @@ class Distribution:
         ]
 
     @staticmethod
-    def bgp() -> str:
+    def bgp(uri: Optional[URIRef] = None) -> str:
         """
         The SPARQL BGP that identifies instances of this class in an RDF dataset.
+        :param uri: optional uri of the element to filter for
         :return: the SPARQL BGP
         """
         return dedent(f"""
-        {{
-            ?distrib a {ADMS.SemanticAssetDistribution.n3()} .
+        {{ {f'BIND( {uri.n3()} AS ?distrib)' if uri else ''}
+            ?distrib a {Distribution.type.n3()} .
             OPTIONAL {{
                 ?distrib {DCTERMS.title.n3()} ?title_en .
                 FILTER langMatches(lang(?title_en), 'en')
@@ -288,7 +296,7 @@ class Distribution:
         :return: the SPARQL CONSTRUCT head
         """
         return dedent(f"""
-            ?distrib a {ADMS.SemanticAssetDistribution.n3()} ;
+            ?distrib a {Distribution.type.n3()} ;
                      {DCTERMS.title.n3()} ?title_en ;
                      {DCTERMS.title.n3()} ?title_it ;
                      {DCTERMS.description.n3()} ?description_en ;
@@ -312,6 +320,7 @@ class Distribution:
 
 @dataclass
 class Project:
+    type: ClassVar[URIRef] = ADMS.Project
     uri: URIRef
     name_en: Optional[Literal]
     name_it: Optional[Literal]
@@ -322,20 +331,21 @@ class Project:
         :return: the list  of triples representing this instance.
         """
         return [
-            (self.uri, RDF.type, ADMS.Project),
+            (self.uri, RDF.type, Project.type),
             (self.uri, L0.name, self.name_en),
             (self.uri, L0.name, self.name_it),
         ]
 
     @staticmethod
-    def bgp() -> str:
+    def bgp(uri: Optional[URIRef] = None) -> str:
         """
         The SPARQL BGP that identifies instances of this class in an RDF dataset.
+        :param uri: optional uri of the element to filter for
         :return: the SPARQL BGP
         """
         return dedent(f"""
-        {{
-            ?project a {ADMS.Project.n3()} .
+        {{ {f'BIND( {uri.n3()} AS ?project)' if uri else ''}
+            ?project a {Project.type.n3()} .
             OPTIONAL {{
                 ?project {L0.name.n3()} ?name_en .
                 FILTER langMatches(lang(?name_en), 'en')
@@ -355,7 +365,7 @@ class Project:
         :return: the SPARQL CONSTRUCT head
         """
         return dedent(f"""
-        ?project a {ADMS.Project.n3()} ;
+        ?project a {Project.type.n3()} ;
                  {L0.name.n3()} ?name_en ;
                  {L0.name.n3()} ?name_it .
         """).strip()
@@ -408,40 +418,44 @@ UNION {Project.bgp()}
 }}
         """.strip()
 
-    def agents(self) -> Iterable[Agent]:
+    def agents(self, uri: Optional[URIRef] = None) -> Iterable[Agent]:
         """
         Returns the list of agents in this dataset.
+        :param uri: the uri of the element to filter for
         :return: the list of agents stored
         """
         return [Agent(*b) for b in self.query(
-            f'SELECT {Agent.vars()} WHERE {Agent.bgp()}'
+            f'SELECT {Agent.vars()} WHERE {Agent.bgp(uri)}'
         )]
 
-    def contactPoints(self) -> Iterable[ContactPoint]:
+    def contactPoints(self, uri: Optional[URIRef] = None) -> Iterable[ContactPoint]:
         """
         Returns the list of contact points in this dataset.
+        :param uri: the uri of the element to filter for
         :return: the list of contact points stored
         """
         return [ContactPoint(*b) for b in self.query(
-            f'SELECT {ContactPoint.vars()} WHERE {ContactPoint.bgp()}'
+            f'SELECT {ContactPoint.vars()} WHERE {ContactPoint.bgp(uri)}'
         )]
 
-    def distributions(self) -> Iterable[Distribution]:
+    def distributions(self, uri: Optional[URIRef] = None) -> Iterable[Distribution]:
         """
         Returns the list of distributions in this dataset.
+        :param uri: the uri of the element to filter for
         :return: the list of distributions stored
         """
         return [Distribution(*b) for b in self.query(
-            f'SELECT {Distribution.vars()} WHERE {Distribution.bgp()}'
+            f'SELECT {Distribution.vars()} WHERE {Distribution.bgp(uri)}'
         )]
 
-    def projects(self) -> Iterable[Project]:
+    def projects(self, uri: Optional[URIRef] = None) -> Iterable[Project]:
         """
         Returns the list of projects in this dataset.
+        :param uri: the uri of the element to filter for
         :return: the list of projects stored
         """
         return [Project(*b) for b in self.query(
-            f'SELECT {Project.vars()} WHERE {Project.bgp()}'
+            f'SELECT {Project.vars()} WHERE {Project.bgp(uri)}'
         )]
 
     def load(self, path: str = None) -> Graph:

--- a/eddy/core/ndc.py
+++ b/eddy/core/ndc.py
@@ -80,12 +80,20 @@ class ADMS(DefinedNamespace):
     _NS = Namespace('https://w3id.org/italia/onto/ADMS/')
 
 
+# Subset of the dcatapit ontology vocabulary
+class DCATAPIT(DefinedNamespace):
+    Agent: URIRef
+    Organization: URIRef
+    _NS = Namespace('http://dati.gov.it/onto/dcatapit#')
+
+
 # Subset of the vcard ontology vocabulary
 class VCARD(DefinedNamespace):
     Kind: URIRef
     fn: URIRef
     hasEmail: URIRef
     hasTelephone: URIRef
+    Organization: URIRef
     _NS = Namespace('http://www.w3.org/2006/vcard/ns#')
 
 
@@ -104,6 +112,7 @@ class Agent:
         """
         return [
             (self.uri, RDF.type, Agent.type),
+            (self.uri, RDF.type, DCATAPIT.Agent),
             (self.uri, FOAF.name, self.name_en),
             (self.uri, FOAF.name, self.name_it),
             (self.uri, DCTERMS.identifier, self.identifier),
@@ -171,6 +180,8 @@ class ContactPoint:
         """
         return [
             (self.uri, RDF.type, ContactPoint.type),
+            (self.uri, RDF.type, DCATAPIT.Organization),
+            (self.uri, RDF.type, VCARD.Organization),
             (self.uri, VCARD.fn, self.fn_en),
             (self.uri, VCARD.fn, self.fn_it),
             (self.uri, VCARD.hasEmail, self.email),
@@ -386,7 +397,6 @@ class NDCDataset(Dataset):
     custom methods that extract the relevant entities for the national data catalog.
     """
     DEFAULT_GRAPH = 'urn:x-eddy:ndc:'
-    STORE_PATH = expandPath('@data/ndc.trig')
 
     def __init__(
         self,
@@ -467,11 +477,11 @@ UNION {Project.bgp()}
         """
         if path:
             return self.parse(path)
-        elif fexists(NDCDataset.STORE_PATH):
-            return self.parse(NDCDataset.STORE_PATH)
+        elif fexists(expandPath('@data/ndc.trig')):
+            return self.parse(expandPath('@data/ndc.trig'))
 
     def save(self) -> None:
         """
         Saves this dataset to the default user destination.
         """
-        self.serialize(NDCDataset.STORE_PATH, format='trig')
+        self.serialize(expandPath('@data/ndc.trig'), format='trig')

--- a/eddy/core/sparql.py
+++ b/eddy/core/sparql.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+
+##########################################################################
+#                                                                        #
+#  Eddy: a graphical editor for the specification of Graphol ontologies  #
+#  Copyright (C) 2015 Daniele Pantaleone <danielepantaleone@me.com>      #
+#                                                                        #
+#  This program is free software: you can redistribute it and/or modify  #
+#  it under the terms of the GNU General Public License as published by  #
+#  the Free Software Foundation, either version 3 of the License, or     #
+#  (at your option) any later version.                                   #
+#                                                                        #
+#  This program is distributed in the hope that it will be useful,       #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+#  GNU General Public License for more details.                          #
+#                                                                        #
+#  You should have received a copy of the GNU General Public License     #
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.  #
+#                                                                        #
+#  #####################                          #####################  #
+#                                                                        #
+#  Graphol is developed by members of the DASI-lab group of the          #
+#  Dipartimento di Ingegneria Informatica, Automatica e Gestionale       #
+#  A.Ruberti at Sapienza University of Rome: http://www.dis.uniroma1.it  #
+#                                                                        #
+#     - Domenico Lembo <lembo@dis.uniroma1.it>                           #
+#     - Valerio Santarelli <santarelli@dis.uniroma1.it>                  #
+#     - Domenico Fabio Savo <savo@dis.uniroma1.it>                       #
+#     - Daniele Pantaleone <pantaleone@dis.uniroma1.it>                  #
+#     - Marco Console <console@dis.uniroma1.it>                          #
+#                                                                        #
+##########################################################################
+
+
+from __future__ import annotations
+
+import json
+from typing import (
+    Iterable,
+    cast,
+)
+
+from PyQt5 import (
+    QtCore,
+    QtNetwork,
+)
+from rdflib import Graph
+from rdflib.term import (
+    BNode,
+    Identifier,
+    Literal,
+    URIRef,
+)
+
+from eddy.core.functions.signals import connect
+from eddy.core.output import getLogger
+
+LOGGER = getLogger()
+
+
+class SPARQLEndpoint(QtCore.QObject):
+    """
+    Object that abstracts a SPARQL endpoint to clients.
+    This supports SELECT and CONSTRUCT queries through direct-POST only,
+    and with JSON and TURTLE response formats, respectively.
+    """
+    sgnConstructFinished = QtCore.pyqtSignal(QtCore.QUrl, Graph)
+    sgnSelectFinished = QtCore.pyqtSignal(QtCore.QUrl, tuple)
+    sgnSPARQLError = QtCore.pyqtSignal(QtCore.QUrl)
+    RequestBody = QtNetwork.QNetworkRequest.Attribute(2101)
+    RequestType = QtNetwork.QNetworkRequest.Attribute(2102)
+
+    def __init__(self, url: str, nmanager: QtNetwork.QNetworkAccessManager) -> None:
+        """
+        Create a new SPARQLEndpoint instance for the given URL.
+
+        :param url: URL of the endpoint to query
+        """
+        super().__init__(nmanager)
+        self._url = url
+
+    #############################################
+    #   PROPERTIES
+    #################################
+
+    @property
+    def nmanager(self) -> QtNetwork.QNetworkAccessManager:
+        """
+        Returns the `QNetworkAccessManager` associated to this instance.
+
+        :return: the `QNetworkAccessManager` of the instance
+        """
+        return cast(QtNetwork.QNetworkAccessManager, self.parent())
+
+    @property
+    def url(self) -> str:
+        """
+        Returns the URL of the associated SPARQL endpoint.
+
+        :return: URL of the SPARQL endpoint
+        """
+        return self._url
+
+    #############################################
+    #   SLOTS
+    #################################
+
+    def onRequestFinished(self) -> None:
+        """
+        Executed when a request completes.
+        """
+        reply = cast(QtNetwork.QNetworkReply, self.sender())
+        try:
+            reply.deleteLater()
+            if (
+                reply.isFinished()
+                and reply.error() == QtNetwork.QNetworkReply.NetworkError.NoError
+            ):
+                body = reply.request().attribute(SPARQLEndpoint.RequestBody)
+                type_ = reply.request().attribute(SPARQLEndpoint.RequestType)
+                if type_ == 'CONSTRUCT':
+                    graph = Graph(bind_namespaces='core')
+                    graph.parse(data=str(reply.readAll(), encoding='utf-8'))  # noqa
+                    self.sgnConstructFinished.emit(reply.url(), graph)
+                elif type_ == 'SELECT':
+                    response = json.loads(str(reply.readAll(), encoding='utf-8'))  # noqa
+                    vars = response['head']['vars']
+                    bindings = response['results']['bindings']
+                    results = SPARQLEndpoint.process_bindings(bindings, vars)
+                    self.sgnSelectFinished.emit(reply.url(), results)
+                else:
+                    LOGGER.error('Unrecognized request type: %s', type_)
+                    self.sgnSPARQLError.emit(reply.url())
+            else:
+                LOGGER.warning('Failed to retrieve update data: %s', reply.errorString())
+                self.sgnSPARQLError.emit(reply.url())
+        except Exception as e:
+            LOGGER.warning('Failed to retrive response data: %s', e)
+            self.sgnSPARQLError.emit(reply.url())
+
+    #############################################
+    #   INTERFACE
+    #################################
+
+    def execConstruct(self, query: str) -> None:
+        """
+        Executes a SPARQL CONSTRUCT query against the endpoint, and returns
+        and rdflib graph with the content of the endpoint response.
+
+        :param query: the SPARQL CONSTRUCT query
+        :return: the graph of the endpoint response
+        """
+        LOGGER.info('Executing SPARQL CONSTRUCT (Endpoint: %s)', self.url)
+        request = SPARQLConstructRequest(QtCore.QUrl(self.url), query)
+        reply = self.nmanager.post(request, query.encode('utf-8'))
+        connect(reply.finished, self.onRequestFinished)
+        # TIMEOUT AFTER 30 SECONDS
+        QtCore.QTimer.singleShot(30000, reply.abort)
+
+    def execSelect(self, query: str) -> None:
+        """
+        Executes a SPARQL SELECT query against the endpoint, and returns a tuple
+        with an element per query variable in the same order as they are specified,
+        converted the corresponding rdflib term.
+
+        :param query: a SPARQL SELECT query
+        :return: tuple with the bindings for variables in the query
+        """
+        LOGGER.info('Executing SPARQL SELECT (Endpoint: %s)', self.url)
+        request = SPARQLSelectRequest(QtCore.QUrl(self.url), query)
+        reply = self.nmanager.post(request, query.encode('utf-8'))
+        connect(reply.finished, self.onRequestFinished)
+        # TIMEOUT AFTER 30 SECONDS
+        QtCore.QTimer.singleShot(30000, reply.abort)
+
+    @staticmethod
+    def process_binding(binding: dict[str, str]) -> Identifier:
+        """
+        Process the binding of a single variable in JSON form.
+
+        The specifications of how the bindings are specified follow
+        the RDF SPARQL JSON results spec:
+        `https://www.w3.org/TR/rdf-sparql-json-res/#variable-binding-results`
+
+        :param binding: the variable binding in JSON form
+        :return: the identifier corresponding to the variable binding
+        """
+        type_, value = binding["type"], binding["value"]
+        if type_ == "uri":
+            return URIRef(value)
+        elif type_ == "literal":
+            return Literal(value, datatype=binding.get("datatype"), lang=binding.get("xml:lang"))
+        elif type_ == "typed-literal":
+            return Literal(value, datatype=URIRef(binding["datatype"]))
+        elif type_ == "bnode":
+            return BNode(value)
+        else:
+            raise ValueError(f"invalid binding type: {type_}")
+
+    @staticmethod
+    def process_bindings(bindings: dict[str, dict], vars: Iterable[str]) -> tuple[Identifier, ...]:
+        """
+        Extracts the bindings from a SPARQL query result by following the order
+        of the variables specified in `vars`.
+
+        The bindings are a list of `Query Solution Object`s which specify
+        a binding for every variable in the head of the query.
+
+        Given variables that have no binding will be mapped to `None`.
+
+        :param bindings: the list of bindings that satisfy the query (i.e. the bindings)
+        :param vars: the list of variables in the head of the query
+        :return: a tuple with one binding for every variable (respecting their order)
+        """
+        return tuple([
+            SPARQLEndpoint.process_binding(bindings[var])
+            if var in bindings and bindings[var] else None
+            for var in vars
+        ])
+
+
+class SPARQLConstructRequest(QtNetwork.QNetworkRequest):
+    """
+    Network request corresponding to a SPARQL CONSTRUCT query request.
+    """
+
+    def __init__(self, url: QtCore.QUrl, query: str) -> None:
+        super().__init__(url)
+        self.setRawHeader(b'Accept', b'text/turtle')
+        self.setRawHeader(b'Content-Type', b'application/sparql-query')
+        self.setAttribute(SPARQLEndpoint.RequestType, 'CONSTRUCT')
+        self.setAttribute(SPARQLEndpoint.RequestBody, query)
+        self.setAttribute(QtNetwork.QNetworkRequest.FollowRedirectsAttribute, True)
+
+
+class SPARQLSelectRequest(QtNetwork.QNetworkRequest):
+    """
+    Network request corresponding to a SPARQL SELECT query request.
+    """
+
+    def __init__(self, url: QtCore.QUrl, query: str) -> None:
+        super().__init__(url)
+        self.setRawHeader(b'Accept', b'application/sparql-results+json')
+        self.setRawHeader(b'Content-Type', b'application/sparql-query')
+        self.setAttribute(SPARQLEndpoint.RequestType, 'SELECT')
+        self.setAttribute(SPARQLEndpoint.RequestBody, query)
+        self.setAttribute(QtNetwork.QNetworkRequest.FollowRedirectsAttribute, True)

--- a/eddy/ui/ndc/agent.py
+++ b/eddy/ui/ndc/agent.py
@@ -1,9 +1,54 @@
-from PyQt5 import QtCore, QtWidgets
+# -*- coding: utf-8 -*-
 
-from eddy.core.ndc import addAgentToStore
+##########################################################################
+#                                                                        #
+#  Eddy: a graphical editor for the specification of Graphol ontologies  #
+#  Copyright (C) 2015 Daniele Pantaleone <danielepantaleone@me.com>      #
+#                                                                        #
+#  This program is free software: you can redistribute it and/or modify  #
+#  it under the terms of the GNU General Public License as published by  #
+#  the Free Software Foundation, either version 3 of the License, or     #
+#  (at your option) any later version.                                   #
+#                                                                        #
+#  This program is distributed in the hope that it will be useful,       #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+#  GNU General Public License for more details.                          #
+#                                                                        #
+#  You should have received a copy of the GNU General Public License     #
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.  #
+#                                                                        #
+#  #####################                          #####################  #
+#                                                                        #
+#  Graphol is developed by members of the DASI-lab group of the          #
+#  Dipartimento di Ingegneria Informatica, Automatica e Gestionale       #
+#  A.Ruberti at Sapienza University of Rome: http://www.dis.uniroma1.it  #
+#                                                                        #
+#     - Domenico Lembo <lembo@dis.uniroma1.it>                           #
+#     - Valerio Santarelli <santarelli@dis.uniroma1.it>                  #
+#     - Domenico Fabio Savo <savo@dis.uniroma1.it>                       #
+#     - Daniele Pantaleone <pantaleone@dis.uniroma1.it>                  #
+#     - Marco Console <console@dis.uniroma1.it>                          #
+#                                                                        #
+##########################################################################
+
+from __future__ import annotations
+
+from PyQt5 import (
+    QtCore,
+    QtWidgets,
+)
+from rdflib import (
+    Literal,
+    URIRef,
+)
+
+from core.ndc import (
+    Agent,
+    NDCDataset,
+)
 from eddy.core.common import HasWidgetSystem
 from eddy.core.functions.signals import connect
-from eddy.core.owl import IRI
 from eddy.ui.fields import StringField
 
 
@@ -11,19 +56,13 @@ class AgentBuilderDialog(QtWidgets.QDialog, HasWidgetSystem):
     """
     Subclass of `QtWidgets.QDialog` used to define annotation assertions.
     """
-    sgnAgentAccepted = QtCore.pyqtSignal()
-    sgnAgentRejected = QtCore.pyqtSignal()
 
-    emptyString = ''
-
-    def __init__(self,session):
+    def __init__(self, parent: QtWidgets.QWidget, dataset: NDCDataset) -> None:
         """
         Initialize the agent builder dialog.
-        :type session: Session
         """
-        super().__init__(session)
-        self.session = session
-        self.project = session.project
+        super().__init__(parent)
+        self.dataset = dataset
 
         #############################################
         # CONFIRMATION BOX
@@ -90,18 +129,20 @@ class AgentBuilderDialog(QtWidgets.QDialog, HasWidgetSystem):
 
         self.setMinimumSize(740, 380)
         self.setWindowTitle('Add Agent')
-        #self.redraw()
 
     #############################################
     #   SLOTS
     #################################
-    @QtCore.pyqtSlot()
-    def accept(self):
-        iri = self.widget('agent_iri_field').text()
-        nameIT = self.widget('agent_ITname_field').text()
-        nameEN = self.widget('agent_ENname_field').text()
-        id = self.widget('agent_id_field').text()
-        addAgentToStore(iri, nameIT, nameEN, id)
-        self.sgnAgentAccepted.emit()
-        super().accept()
 
+    @QtCore.pyqtSlot()
+    def accept(self) -> None:
+        agent = Agent(
+            URIRef(self.widget('agent_iri_field').text().strip()),
+            Literal(self.widget('agent_ENname_field').text().strip(), lang='en'),
+            Literal(self.widget('agent_ITname_field').text().strip(), lang='it'),
+            Literal(self.widget('agent_id_field').text().strip()),
+        )
+        for triple in agent.triples():
+            self.dataset.add(triple)
+        self.dataset.save()
+        super().accept()

--- a/eddy/ui/ndc/distribution.py
+++ b/eddy/ui/ndc/distribution.py
@@ -1,9 +1,54 @@
-from PyQt5 import QtCore, QtWidgets
+# -*- coding: utf-8 -*-
 
-from eddy.core.ndc import addDistributionToStore
+##########################################################################
+#                                                                        #
+#  Eddy: a graphical editor for the specification of Graphol ontologies  #
+#  Copyright (C) 2015 Daniele Pantaleone <danielepantaleone@me.com>      #
+#                                                                        #
+#  This program is free software: you can redistribute it and/or modify  #
+#  it under the terms of the GNU General Public License as published by  #
+#  the Free Software Foundation, either version 3 of the License, or     #
+#  (at your option) any later version.                                   #
+#                                                                        #
+#  This program is distributed in the hope that it will be useful,       #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+#  GNU General Public License for more details.                          #
+#                                                                        #
+#  You should have received a copy of the GNU General Public License     #
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.  #
+#                                                                        #
+#  #####################                          #####################  #
+#                                                                        #
+#  Graphol is developed by members of the DASI-lab group of the          #
+#  Dipartimento di Ingegneria Informatica, Automatica e Gestionale       #
+#  A.Ruberti at Sapienza University of Rome: http://www.dis.uniroma1.it  #
+#                                                                        #
+#     - Domenico Lembo <lembo@dis.uniroma1.it>                           #
+#     - Valerio Santarelli <santarelli@dis.uniroma1.it>                  #
+#     - Domenico Fabio Savo <savo@dis.uniroma1.it>                       #
+#     - Daniele Pantaleone <pantaleone@dis.uniroma1.it>                  #
+#     - Marco Console <console@dis.uniroma1.it>                          #
+#                                                                        #
+##########################################################################
+
+from __future__ import annotations
+
+from PyQt5 import (
+    QtCore,
+    QtWidgets,
+)
+from rdflib import (
+    Literal,
+    URIRef,
+)
+
+from core.ndc import (
+    Distribution,
+    NDCDataset,
+)
 from eddy.core.common import HasWidgetSystem
 from eddy.core.functions.signals import connect
-from eddy.core.owl import IRI
 from eddy.ui.fields import StringField
 
 
@@ -11,19 +56,13 @@ class DistributionBuilderDialog(QtWidgets.QDialog, HasWidgetSystem):
     """
     Subclass of `QtWidgets.QDialog` used to define annotation assertions.
     """
-    sgnDistributionAccepted = QtCore.pyqtSignal()
-    sgnDistributionRejected = QtCore.pyqtSignal()
 
-    emptyString = ''
-
-    def __init__(self,session):
+    def __init__(self, parent: QtWidgets.QWidget, dataset: NDCDataset) -> None:
         """
         Initialize the distribution builder dialog.
-        :type session: Session
         """
-        super().__init__(session)
-        self.session = session
-        self.project = session.project
+        super().__init__(parent)
+        self.dataset = dataset
 
         #############################################
         # CONFIRMATION BOX
@@ -106,15 +145,20 @@ class DistributionBuilderDialog(QtWidgets.QDialog, HasWidgetSystem):
 
         layout = QtWidgets.QFormLayout()
         layout.addRow(self.widget('distribution_iri_label'), self.widget('distribution_iri_field'))
-        layout.addRow(self.widget('distribution_title_label'), self.widget('distribution_ITtitle_field'))
+        layout.addRow(self.widget('distribution_title_label'),
+                      self.widget('distribution_ITtitle_field'))
         layout.addRow(self.widget('no_label'), self.widget('distribution_ENtitle_field'))
         layout.addRow(self.widget('distribution_description_label'),
                       self.widget('distribution_ITdescription_field'))
         layout.addRow(self.widget('no_label'), self.widget('distribution_ENdescription_field'))
-        layout.addRow(self.widget('distribution_format_label'), self.widget('distribution_format_field'))
-        layout.addRow(self.widget('distribution_license_label'), self.widget('distribution_license_field'))
-        layout.addRow(self.widget('distribution_accessURL_label'), self.widget('distribution_accessURL_field'))
-        layout.addRow(self.widget('distribution_downloadURL_label'), self.widget('distribution_downloadURL_field'))
+        layout.addRow(self.widget('distribution_format_label'),
+                      self.widget('distribution_format_field'))
+        layout.addRow(self.widget('distribution_license_label'),
+                      self.widget('distribution_license_field'))
+        layout.addRow(self.widget('distribution_accessURL_label'),
+                      self.widget('distribution_accessURL_field'))
+        layout.addRow(self.widget('distribution_downloadURL_label'),
+                      self.widget('distribution_downloadURL_field'))
 
         widget = QtWidgets.QWidget()
         widget.setLayout(layout)
@@ -129,22 +173,25 @@ class DistributionBuilderDialog(QtWidgets.QDialog, HasWidgetSystem):
 
         self.setMinimumSize(740, 380)
         self.setWindowTitle('Add Distribution')
-        #self.redraw()
 
     #############################################
     #   SLOTS
     #################################
+
     @QtCore.pyqtSlot()
-    def accept(self):
-        iri = self.widget('distribution_iri_field').text()
-        titleIT = self.widget('distribution_ITtitle_field').text()
-        titleEN = self.widget('distribution_ENtitle_field').text()
-        descriptionIT = self.widget('distribution_ITdescription_field').text()
-        descriptionEN = self.widget('distribution_ENdescription_field').text()
-        format = self.widget('distribution_format_field').text()
-        license = self.widget('distribution_license_field').text()
-        accessURL = self.widget('distribution_accessURL_field').text()
-        downloadURL = self.widget('distribution_downloadURL_field').text()
-        addDistributionToStore(iri, titleIT, titleEN, descriptionIT, descriptionEN, format, license, accessURL, downloadURL)
-        self.sgnDistributionAccepted.emit()
+    def accept(self) -> None:
+        distrib = Distribution(
+            URIRef(self.widget('distribution_iri_field').text().strip()),
+            Literal(self.widget('distribution_ENtitle_field').text().strip(), lang='en'),
+            Literal(self.widget('distribution_ITtitle_field').text().strip(), lang='it'),
+            Literal(self.widget('distribution_ENdescription_field').text().strip(), lang='en'),
+            Literal(self.widget('distribution_ITdescription_field').text().strip(), lang='it'),
+            Literal(self.widget('distribution_format_field').text().strip()),
+            Literal(self.widget('distribution_license_field').text().strip()),
+            URIRef(self.widget('distribution_accessURL_field').text().strip()),
+            URIRef(self.widget('distribution_downloadURL_field').text().strip()),
+        )
+        for triple in distrib.triples():
+            self.dataset.add(triple)
+        self.dataset.save()
         super().accept()

--- a/eddy/ui/ndc/project.py
+++ b/eddy/ui/ndc/project.py
@@ -1,9 +1,54 @@
-from PyQt5 import QtCore, QtWidgets
+# -*- coding: utf-8 -*-
 
-from eddy.core.ndc import addProjectToStore
+##########################################################################
+#                                                                        #
+#  Eddy: a graphical editor for the specification of Graphol ontologies  #
+#  Copyright (C) 2015 Daniele Pantaleone <danielepantaleone@me.com>      #
+#                                                                        #
+#  This program is free software: you can redistribute it and/or modify  #
+#  it under the terms of the GNU General Public License as published by  #
+#  the Free Software Foundation, either version 3 of the License, or     #
+#  (at your option) any later version.                                   #
+#                                                                        #
+#  This program is distributed in the hope that it will be useful,       #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+#  GNU General Public License for more details.                          #
+#                                                                        #
+#  You should have received a copy of the GNU General Public License     #
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.  #
+#                                                                        #
+#  #####################                          #####################  #
+#                                                                        #
+#  Graphol is developed by members of the DASI-lab group of the          #
+#  Dipartimento di Ingegneria Informatica, Automatica e Gestionale       #
+#  A.Ruberti at Sapienza University of Rome: http://www.dis.uniroma1.it  #
+#                                                                        #
+#     - Domenico Lembo <lembo@dis.uniroma1.it>                           #
+#     - Valerio Santarelli <santarelli@dis.uniroma1.it>                  #
+#     - Domenico Fabio Savo <savo@dis.uniroma1.it>                       #
+#     - Daniele Pantaleone <pantaleone@dis.uniroma1.it>                  #
+#     - Marco Console <console@dis.uniroma1.it>                          #
+#                                                                        #
+##########################################################################
+
+from __future__ import annotations
+
+from PyQt5 import (
+    QtCore,
+    QtWidgets,
+)
+from rdflib import (
+    Literal,
+    URIRef,
+)
+
+from core.ndc import (
+    Project,
+    NDCDataset,
+)
 from eddy.core.common import HasWidgetSystem
 from eddy.core.functions.signals import connect
-from eddy.core.owl import IRI
 from eddy.ui.fields import StringField
 
 
@@ -11,19 +56,13 @@ class ProjectBuilderDialog(QtWidgets.QDialog, HasWidgetSystem):
     """
     Subclass of `QtWidgets.QDialog` used to define annotation assertions.
     """
-    sgnProjectAccepted = QtCore.pyqtSignal()
-    sgnProjectRejected = QtCore.pyqtSignal()
 
-    emptyString = ''
-
-    def __init__(self,session):
+    def __init__(self, parent: QtWidgets.QWidget, dataset: NDCDataset) -> None:
         """
         Initialize the project builder dialog.
-        :type session: Session
         """
-        super().__init__(session)
-        self.session = session
-        self.project = session.project
+        super().__init__(parent)
+        self.dataset = dataset
 
         #############################################
         # CONFIRMATION BOX
@@ -82,16 +121,19 @@ class ProjectBuilderDialog(QtWidgets.QDialog, HasWidgetSystem):
 
         self.setMinimumSize(740, 380)
         self.setWindowTitle('Add Project')
-        #self.redraw()
 
     #############################################
     #   SLOTS
     #################################
+
     @QtCore.pyqtSlot()
-    def accept(self):
-        iri = self.widget('project_iri_field').text()
-        nameIT = self.widget('project_ITname_field').text()
-        nameEN = self.widget('project_ENname_field').text()
-        addProjectToStore(iri, nameIT, nameEN)
-        self.sgnProjectAccepted.emit()
+    def accept(self) -> None:
+        project = Project(
+            URIRef(self.widget('project_iri_field').text().strip()),
+            Literal(self.widget('project_ENname_field').text().strip(), lang='en'),
+            Literal(self.widget('project_ITname_field').text().strip(), lang='it'),
+        )
+        for triple in project.triples():
+            self.dataset.add(triple)
+        self.dataset.save()
         super().accept()


### PR DESCRIPTION
Apro intanto questa PR che contiene l'implementazione Qt di uno SPARQL client, il dataset salvato come singolo file RDF multigrafo (dove ogni grafo ha come contesto la URI dell'endpoint di provenienza) e una proposta per semplificare il passaggio degli oggetti NDC tramite semplici dataclass che astraggono un pò gli utilizzatori dal dover manipolare tuple o addirittura query SPARQL, basta chiedere al dataset `agents()`, `projects()`, ecc.. e ti da la lista dei rispettivi oggetti (`Agent`, `Project`, e così via).

Se concordi con questa modifica va terminata la modifica dell'ontology manager e integrata la parte dell'esportazione OWL (su cui ho già fatto delle prove e capito come ci conviene procedere) e poi si può integrare in develop. A queste ci posso pensare io.